### PR TITLE
Initializing NumSC2CtrlGlob. Was uninitialized earlier.

### DIFF
--- a/glue-codes/fast-farm/src/FASTWrapper.f90
+++ b/glue-codes/fast-farm/src/FASTWrapper.f90
@@ -120,6 +120,7 @@ SUBROUTINE FWrap_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Init
       ExternInitData%LidRadialVel = .false.
       
          !.... supercontroller (currently unused) ....
+      ExternInitData%NumSC2CtrlGlob = 0 ! "number of controller inputs [from supercontroller]"
       ExternInitData%NumSC2Ctrl = 0 ! "number of controller inputs [from supercontroller]"
       ExternInitData%NumCtrl2SC = 0 ! "number of controller outputs [to supercontroller]"
    


### PR DESCRIPTION
This was causing the code to not run on Peregrine. May be Intel fortran initializes these variables to 0 by default.