### PR TITLE
FAST Farm infrastructure improvements

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -115,14 +115,14 @@ jobs:
             -DBUILD_TESTING:BOOL=ON \
             -DCTEST_PLOT_ERRORS:BOOL=ON \
             ${GITHUB_WORKSPACE}
-      - name: Build FAST-Farm
+      - name: Build FAST.Farm
         # if: contains(github.event.head_commit.message, 'Action - Test All') || contains(github.event.pull_request.labels.*.name, 'Action - Test All') 
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake --build . --target fast-farm -- -j ${{env.NUM_PROCS}}
+          cmake --build . --target FAST.Farm -- -j ${{env.NUM_PROCS}}
           cmake --build . --target regression_tests -- -j ${{env.NUM_PROCS}}
 
-      - name: Run FAST-Farm tests
+      - name: Run FAST.Farm tests
         # if: contains(github.event.head_commit.message, 'Action - Test All') || contains(github.event.pull_request.labels.*.name, 'Action - Test All') 
         run: |
           ctest -VV -L fastfarm

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -84,6 +84,58 @@ jobs:
             !${{runner.workspace}}/build/reg_tests/glue-codes/openfast/UAE_VI
             !${{runner.workspace}}/build/reg_tests/glue-codes/openfast/WP_Baseline
 
+  fastfarm-regression-test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Bokeh==1.4
+
+      - name: Setup Workspace
+        run: cmake -E make_directory ${{runner.workspace}}/build
+      - name: Configure Build
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          cmake \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install \
+            -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
+            -DBUILD_FAST_FARM:BOOL=ON \
+            -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
+      - name: Build FAST-Farm
+        # if: contains(github.event.head_commit.message, 'Action - Test All') || contains(github.event.pull_request.labels.*.name, 'Action - Test All') 
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          cmake --build . --target fast-farm -- -j ${{env.NUM_PROCS}}
+          cmake --build . --target regression_tests -- -j ${{env.NUM_PROCS}}
+
+      - name: Run FAST-Farm tests
+        # if: contains(github.event.head_commit.message, 'Action - Test All') || contains(github.event.pull_request.labels.*.name, 'Action - Test All') 
+        run: |
+          ctest -VV -L fastfarm
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+
+      - name: Failing test artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: test-results
+          path: |
+            ${{runner.workspace}}/build/reg_tests/glue-codes/fastfarm
+
   unit-test:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -110,6 +110,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install \
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DBUILD_FAST_FARM:BOOL=ON \
+            -DOPENMP:BOOL=ON \
             -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
             -DBUILD_TESTING:BOOL=ON \
             -DCTEST_PLOT_ERRORS:BOOL=ON \

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Run FAST.Farm tests
         # if: contains(github.event.head_commit.message, 'Action - Test All') || contains(github.event.pull_request.labels.*.name, 'Action - Test All') 
         run: |
-          ctest -VV -L fastfarm
+          ctest -VV -L fastfarm -j ${{env.NUM_PROCS}}
         working-directory: ${{runner.workspace}}/build
         shell: bash
 

--- a/glue-codes/fast-farm/CMakeLists.txt
+++ b/glue-codes/fast-farm/CMakeLists.txt
@@ -31,7 +31,7 @@ if(OPENMP_FOUND)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 endif()
 
-add_executable(fast-farm
+add_executable(FAST.Farm
   src/FAST_Farm_IO.f90
   src/FAST_Farm_Subs.f90
   src/FASTWrapper.f90
@@ -39,8 +39,8 @@ add_executable(fast-farm
   src/FAST_Farm_Types.f90
   src/FASTWrapper_Types.f90)
   
-target_link_libraries(fast-farm openfast_postlib openfast_prelib nwtclibs scfastlib sctypeslib awaelib wdlib)
-set_property(TARGET fast-farm PROPERTY LINKER_LANGUAGE Fortran)
+target_link_libraries(FAST.Farm openfast_postlib openfast_prelib nwtclibs scfastlib sctypeslib awaelib wdlib)
+set_property(TARGET FAST.Farm PROPERTY LINKER_LANGUAGE Fortran)
 
 string(TOUPPER ${CMAKE_Fortran_COMPILER_ID} _compiler_id)
 string(TOUPPER ${CMAKE_BUILD_TYPE} _build_type)
@@ -52,5 +52,5 @@ if (${_compiler_id} STREQUAL "GNU" AND ${_build_type} STREQUAL "RELEASE")
   set_source_files_properties(src/FASTWrapper_Types.f90 PROPERTIES COMPILE_FLAGS "-fno-var-tracking -fno-var-tracking-assignments")
 endif()
 
-install(TARGETS fast-farm
+install(TARGETS FAST.Farm
   RUNTIME DESTINATION bin)

--- a/glue-codes/fast-farm/CMakeLists.txt
+++ b/glue-codes/fast-farm/CMakeLists.txt
@@ -38,5 +38,15 @@ add_executable(openfast-farm
 target_link_libraries(openfast-farm openfast_postlib openfast_prelib nwtclibs scfastlib sctypeslib awaelib wdlib)
 set_property(TARGET openfast-farm PROPERTY LINKER_LANGUAGE Fortran)
 
+string(TOUPPER ${CMAKE_Fortran_COMPILER_ID} _compiler_id)
+string(TOUPPER ${CMAKE_BUILD_TYPE} _build_type)
+if (${_compiler_id} STREQUAL "GNU" AND ${_build_type} STREQUAL "RELEASE")
+  # With variable tracking enabled, the compile step frequently aborts on large modules and
+  # restarts with this option off. Disabling in Release mode avoids this problem when compiling with
+  # full optimizations, but leaves it enabled for RelWithDebInfo which adds both -O2 and -g flags.
+  # https://gcc.gnu.org/onlinedocs/gcc/Debugging-Options.html
+  set_source_files_properties(src/FASTWrapper_Types.f90 PROPERTIES COMPILE_FLAGS "-fno-var-tracking -fno-var-tracking-assignments")
+endif()
+
 install(TARGETS openfast-farm
   RUNTIME DESTINATION bin)

--- a/glue-codes/fast-farm/CMakeLists.txt
+++ b/glue-codes/fast-farm/CMakeLists.txt
@@ -27,7 +27,7 @@ if(OPENMP_FOUND)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 endif()
 
-add_executable(openfast-farm
+add_executable(fast-farm
   src/FAST_Farm_IO.f90
   src/FAST_Farm_Subs.f90
   src/FASTWrapper.f90
@@ -35,8 +35,8 @@ add_executable(openfast-farm
   src/FAST_Farm_Types.f90
   src/FASTWrapper_Types.f90)
   
-target_link_libraries(openfast-farm openfast_postlib openfast_prelib nwtclibs scfastlib sctypeslib awaelib wdlib)
-set_property(TARGET openfast-farm PROPERTY LINKER_LANGUAGE Fortran)
+target_link_libraries(fast-farm openfast_postlib openfast_prelib nwtclibs scfastlib sctypeslib awaelib wdlib)
+set_property(TARGET fast-farm PROPERTY LINKER_LANGUAGE Fortran)
 
 string(TOUPPER ${CMAKE_Fortran_COMPILER_ID} _compiler_id)
 string(TOUPPER ${CMAKE_BUILD_TYPE} _build_type)
@@ -48,5 +48,5 @@ if (${_compiler_id} STREQUAL "GNU" AND ${_build_type} STREQUAL "RELEASE")
   set_source_files_properties(src/FASTWrapper_Types.f90 PROPERTIES COMPILE_FLAGS "-fno-var-tracking -fno-var-tracking-assignments")
 endif()
 
-install(TARGETS openfast-farm
+install(TARGETS fast-farm
   RUNTIME DESTINATION bin)

--- a/glue-codes/fast-farm/CMakeLists.txt
+++ b/glue-codes/fast-farm/CMakeLists.txt
@@ -19,7 +19,11 @@ if (GENERATE_TYPES)
   generate_f90_types(src/FAST_Farm_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/FAST_Farm_Types.f90 -noextrap)
 endif()
 
-FIND_PACKAGE( OpenMP REQUIRED)
+FIND_PACKAGE( OpenMP )
+if (NOT ${OPENMP_Fortran_FOUND} )
+  message(FATAL_ERROR "CMake could not find the OpenMP Fortran libraries.")
+endif()
+
 if(OPENMP_FOUND)
   set(CMAKE_FORTRAN_FLAGS "${CMAKE_FORTRAN_FLAGS} ${OpenMP_FORTRAN_FLAGS}")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")

--- a/reg_tests/CMakeLists.txt
+++ b/reg_tests/CMakeLists.txt
@@ -37,6 +37,9 @@ option(CTEST_PLOT_ERRORS "Generate plots of regression test errors." OFF)
 # Set the OpenFAST executable configuration option and default
 set(CTEST_OPENFAST_EXECUTABLE "${CMAKE_BINARY_DIR}/glue-codes/openfast/openfast" CACHE FILEPATH "Specify the OpenFAST executable to use in testing.")
 
+# Set the FASTFarm executable configuration option and default
+set(CTEST_FASTFARM_EXECUTABLE "${CMAKE_BINARY_DIR}/glue-codes/fast-farm/fast-farm" CACHE FILEPATH "Specify the FASTFarm executable to use in testing.")
+
 # Set the AeroDyn executable configuration option and default
 set(CTEST_AERODYN_EXECUTABLE "${CMAKE_BINARY_DIR}/modules/aerodyn/aerodyn_driver" CACHE FILEPATH "Specify the AeroDyn driver executable to use in testing.")
 
@@ -80,28 +83,60 @@ foreach(turbineDirectory 5MW_Baseline AOC AWT27 SWRT UAE_VI WP_Baseline)
   DESTINATION "${CTEST_BINARY_DIR}/glue-codes/openfast/")
 endforeach()
 
+## fastfarm seed
+foreach(turbineDirectory 5MW_Baseline)
+  file(COPY "${CMAKE_CURRENT_LIST_DIR}/r-test/glue-codes/fast-farm/${turbineDirectory}"
+  DESTINATION "${CTEST_BINARY_DIR}/glue-codes/fast-farm/")
+endforeach()
+
 # add the tests
 include(${CMAKE_CURRENT_LIST_DIR}/CTestList.cmake)
 
+# Copy the DISCON controllers to the 5MW turbine directories
 set(src "${CMAKE_CURRENT_LIST_DIR}/r-test/glue-codes/openfast/5MW_Baseline/ServoData")
-set(dest "${CTEST_BINARY_DIR}/glue-codes/openfast/5MW_Baseline/ServoData/")
+
+set(of_dest "${CTEST_BINARY_DIR}/glue-codes/openfast/5MW_Baseline/ServoData/")
 add_custom_command(
-  OUTPUT "${dest}/DISCON.dll"
+  OUTPUT "${of_dest}/DISCON.dll"
   DEPENDS DISCON
-  COMMAND "${CMAKE_COMMAND}" -E copy "${src}/DISCON/build/DISCON.dll" "${dest}"
+  COMMAND "${CMAKE_COMMAND}" -E copy "${src}/DISCON/build/DISCON.dll" "${of_dest}"
 )
 add_custom_command(
-  OUTPUT "${dest}/DISCON_ITIBarge.dll"
+  OUTPUT "${of_dest}/DISCON_ITIBarge.dll"
   DEPENDS DISCON_ITIBarge
-  COMMAND "${CMAKE_COMMAND}" -E copy "${src}/DISCON_ITI/build/DISCON_ITIBarge.dll" "${dest}"
+  COMMAND "${CMAKE_COMMAND}" -E copy "${src}/DISCON_ITI/build/DISCON_ITIBarge.dll" "${of_dest}"
   )
 add_custom_command(
-  OUTPUT "${dest}/DISCON_OC3Hywind.dll"
+  OUTPUT "${of_dest}/DISCON_OC3Hywind.dll"
   DEPENDS DISCON_OC3Hywind
-  COMMAND "${CMAKE_COMMAND}" -E copy "${src}/DISCON_OC3/build/DISCON_OC3Hywind.dll" "${dest}"
+  COMMAND "${CMAKE_COMMAND}" -E copy "${src}/DISCON_OC3/build/DISCON_OC3Hywind.dll" "${of_dest}"
+)
+
+set(ff_dest "${CTEST_BINARY_DIR}/glue-codes/fast-farm/5MW_Baseline/ServoData/")
+add_custom_command(
+  OUTPUT "${ff_dest}/DISCON_WT1.dll"
+  DEPENDS DISCON
+  COMMAND "${CMAKE_COMMAND}" -E copy "${src}/DISCON/build/DISCON.dll" "${ff_dest}/DISCON_WT1.dll"
+)
+add_custom_command(
+  OUTPUT "${ff_dest}/DISCON_WT2.dll"
+  DEPENDS DISCON
+  COMMAND "${CMAKE_COMMAND}" -E copy "${src}/DISCON/build/DISCON.dll" "${ff_dest}/DISCON_WT2.dll"
+)
+add_custom_command(
+  OUTPUT "${ff_dest}/DISCON_WT3.dll"
+  DEPENDS DISCON
+  COMMAND "${CMAKE_COMMAND}" -E copy "${src}/DISCON/build/DISCON.dll" "${ff_dest}/DISCON_WT3.dll"
 )
 
 add_custom_target(
   regression_tests
-  DEPENDS openfast "${dest}/DISCON.dll" "${dest}/DISCON_ITIBarge.dll" "${dest}/DISCON_OC3Hywind.dll"
+  DEPENDS
+    openfast
+    "${of_dest}/DISCON.dll"
+    "${of_dest}/DISCON_ITIBarge.dll"
+    "${of_dest}/DISCON_OC3Hywind.dll"
+    "${ff_dest}/DISCON_WT1.dll"
+    "${ff_dest}/DISCON_WT2.dll"
+    "${ff_dest}/DISCON_WT3.dll"
 )

--- a/reg_tests/CMakeLists.txt
+++ b/reg_tests/CMakeLists.txt
@@ -38,7 +38,7 @@ option(CTEST_PLOT_ERRORS "Generate plots of regression test errors." OFF)
 set(CTEST_OPENFAST_EXECUTABLE "${CMAKE_BINARY_DIR}/glue-codes/openfast/openfast" CACHE FILEPATH "Specify the OpenFAST executable to use in testing.")
 
 # Set the FASTFarm executable configuration option and default
-set(CTEST_FASTFARM_EXECUTABLE "${CMAKE_BINARY_DIR}/glue-codes/fast-farm/fast-farm" CACHE FILEPATH "Specify the FASTFarm executable to use in testing.")
+set(CTEST_FASTFARM_EXECUTABLE "${CMAKE_BINARY_DIR}/glue-codes/fast-farm/FAST.Farm" CACHE FILEPATH "Specify the FASTFarm executable to use in testing.")
 
 # Set the AeroDyn executable configuration option and default
 set(CTEST_AERODYN_EXECUTABLE "${CMAKE_BINARY_DIR}/modules/aerodyn/aerodyn_driver" CACHE FILEPATH "Specify the AeroDyn driver executable to use in testing.")

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -74,7 +74,15 @@ function(of_regression_aeroacoustic TESTNAME LABEL)
   regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} ${TESTNAME} "${LABEL}")
 endfunction(of_regression_aeroacoustic)
 
-# beamdyn
+# FAST Farm
+function(ff_regression TESTNAME LABEL)
+  set(TEST_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/executeFASTFarmRegressionCase.py")
+  set(FASTFARM_EXECUTABLE "${CTEST_FASTFARM_EXECUTABLE}")
+  set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
+  set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/glue-codes/fast-farm")
+  regression(${TEST_SCRIPT} ${FASTFARM_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} ${TESTNAME} "${LABEL}")
+endfunction(ff_regression)
+
 # openfast linearized
 function(of_regression_linear TESTNAME LABEL)
   set(TEST_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/executeOpenfastLinearRegressionCase.py")
@@ -164,6 +172,9 @@ of_regression_linear("Ideal_Beam_Fixed_Free_Linear" "openfast;linear;beamdyn")
 of_regression_linear("Ideal_Beam_Free_Free_Linear"  "openfast;linear;beamdyn")
 of_regression_linear("5MW_Land_BD_Linear"           "openfast;linear;beamdyn;servodyn")
 of_regression_linear("5MW_OC4Semi_Linear"           "openfast;linear;hydrodyn;servodyn")
+
+# FAST Farm regression tests
+ff_regression("TSinflow"  "fastfarm")
 
 # AeroDyn regression tests
 ad_regression("ad_timeseries_shutdown"      "aerodyn;bem")

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -175,6 +175,7 @@ of_regression_linear("5MW_OC4Semi_Linear"           "openfast;linear;hydrodyn;se
 
 # FAST Farm regression tests
 ff_regression("TSinflow"  "fastfarm")
+ff_regression("LESinflow"  "fastfarm")
 
 # AeroDyn regression tests
 ad_regression("ad_timeseries_shutdown"      "aerodyn;bem")

--- a/reg_tests/executeFASTFarmRegressionCase.py
+++ b/reg_tests/executeFASTFarmRegressionCase.py
@@ -1,0 +1,163 @@
+#
+# Copyright 2017 National Renewable Energy Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+    This program executes FASTFarm and a regression test for a single test case.
+    The test data is contained in a git submodule, r-test, which must be initialized
+    prior to running. See the r-test README or OpenFAST documentation for more info.
+
+    Get usage with: `executeFASTFarmRegressionCase.py -h`
+"""
+
+import os
+import sys
+basepath = os.path.sep.join(sys.argv[0].split(os.path.sep)[:-1]) if os.path.sep in sys.argv[0] else "."
+sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
+import argparse
+import shutil
+import subprocess
+import rtestlib as rtl
+import openfastDrivers
+import pass_fail
+from errorPlotting import exportCaseSummary
+
+##### Helper functions
+def ignoreBaselineItems(directory, contents):
+    itemFilter = ['linux-intel', 'linux-gnu', 'macos-gnu', 'windows-intel']
+    caught = []
+    for c in contents:
+        if c in itemFilter:
+            caught.append(c)
+    return tuple(caught)
+
+##### Main program
+
+### Store the python executable for future python calls
+pythonCommand = sys.executable
+
+### Verify input arguments
+parser = argparse.ArgumentParser(description="Executes OpenFAST and a regression test for a single test case.")
+parser.add_argument("caseName", metavar="Case-Name", type=str, nargs=1, help="The name of the test case.")
+parser.add_argument("executable", metavar="OpenFAST", type=str, nargs=1, help="The path to the OpenFAST executable.")
+parser.add_argument("sourceDirectory", metavar="path/to/openfast_repo", type=str, nargs=1, help="The path to the OpenFAST repository.")
+parser.add_argument("buildDirectory", metavar="path/to/openfast_repo/build", type=str, nargs=1, help="The path to the OpenFAST repository build directory.")
+parser.add_argument("tolerance", metavar="Test-Tolerance", type=float, nargs=1, help="Tolerance defining pass or failure in the regression test.")
+parser.add_argument("systemName", metavar="System-Name", type=str, nargs=1, help="The current system\'s name: [Darwin,Linux,Windows]")
+parser.add_argument("compilerId", metavar="Compiler-Id", type=str, nargs=1, help="The compiler\'s id: [Intel,GNU]")
+parser.add_argument("-p", "-plot", dest="plot", action='store_true', help="bool to include plots in failed cases")
+parser.add_argument("-n", "-no-exec", dest="noExec", action='store_true', help="bool to prevent execution of the test cases")
+parser.add_argument("-v", "-verbose", dest="verbose", action='store_true', help="bool to include verbose system output")
+
+args = parser.parse_args()
+
+caseName = args.caseName[0]
+executable = args.executable[0]
+sourceDirectory = args.sourceDirectory[0]
+buildDirectory = args.buildDirectory[0]
+tolerance = args.tolerance[0]
+systemName = args.systemName[0]
+compilerId = args.compilerId[0]
+plotError = args.plot
+noExec = args.noExec
+verbose = args.verbose
+
+# validate inputs
+rtl.validateExeOrExit(executable)
+rtl.validateDirOrExit(sourceDirectory)
+if not os.path.isdir(buildDirectory):
+    os.makedirs(buildDirectory)
+
+### Map the system and compiler configurations to a solution set
+# Internal names -> Human readable names
+systemName_map = {
+    "darwin": "macos",
+    "linux": "linux",
+    "windows": "windows"
+}
+compilerId_map = {
+    "gnu": "gnu",
+    "intel": "intel"
+}
+# Build the target output directory name or choose the default
+supportedBaselines = ["macos-gnu", "linux-intel", "linux-gnu", "windows-intel"]
+targetSystem = systemName_map.get(systemName.lower(), "")
+targetCompiler = compilerId_map.get(compilerId.lower(), "")
+outputType = os.path.join(targetSystem+"-"+targetCompiler)
+if outputType not in supportedBaselines:
+    outputType = supportedBaselines[0]
+print("-- Using gold standard files with machine-compiler type {}".format(outputType))
+
+### Build the filesystem navigation variables for running openfast on the test case
+regtests = os.path.join(sourceDirectory, "reg_tests")
+lib = os.path.join(regtests, "lib")
+rtest = os.path.join(regtests, "r-test")
+moduleDirectory = os.path.join(rtest, "glue-codes", "fast-farm")
+inputsDirectory = os.path.join(moduleDirectory, caseName)
+targetOutputDirectory = os.path.join(inputsDirectory) #, outputType)
+testBuildDirectory = os.path.join(buildDirectory, caseName)
+
+# verify all the required directories exist
+if not os.path.isdir(rtest):
+    rtl.exitWithError("The test data directory, {}, does not exist. If you haven't already, run `git submodule update --init --recursive`".format(rtest))
+if not os.path.isdir(targetOutputDirectory):
+    rtl.exitWithError("The test data outputs directory, {}, does not exist. Try running `git submodule update`".format(targetOutputDirectory))
+if not os.path.isdir(inputsDirectory):
+    rtl.exitWithError("The test data inputs directory, {}, does not exist. Verify your local repository is up to date.".format(inputsDirectory))
+
+# create the local output directory if it does not already exist
+if not os.path.isdir(testBuildDirectory):
+    shutil.copytree(inputsDirectory, testBuildDirectory, ignore=ignoreBaselineItems)
+
+### Run openfast on the test case
+noExec = True
+if not noExec:
+    caseInputFile = os.path.join(testBuildDirectory, caseName + ".fstf")
+    returnCode = openfastDrivers.runOpenfastCase(caseInputFile, executable)
+    if returnCode != 0:
+        rtl.exitWithError("")
+    
+### Build the filesystem navigation variables for running the regression test
+localOutFile = os.path.join(testBuildDirectory, caseName + ".out")
+baselineOutFile = os.path.join(targetOutputDirectory, caseName + ".out")
+rtl.validateFileOrExit(localOutFile)
+rtl.validateFileOrExit(baselineOutFile)
+
+testData, testInfo, testPack = pass_fail.readFASTOut(localOutFile)
+baselineData, baselineInfo, _ = pass_fail.readFASTOut(baselineOutFile)
+performance = pass_fail.calculateNorms(testData, baselineData)
+normalizedNorm = performance[:, 1]
+
+# export all case summaries
+results = list(zip(testInfo["attribute_names"], [*performance]))
+results_max = performance.max(axis=0)
+exportCaseSummary(testBuildDirectory, caseName, results, results_max, tolerance)
+
+# failing case
+if not pass_fail.passRegressionTest(normalizedNorm, tolerance):
+    if plotError:
+        from errorPlotting import finalizePlotDirectory, plotOpenfastError
+        for channel in testInfo["attribute_names"]:
+            try:
+                plotOpenfastError(localOutFile, baselineOutFile, channel)
+            except:
+                error = sys.exc_info()[1]
+                print("Error generating plots: {}".format(error))
+        finalizePlotDirectory(localOutFile, testInfo["attribute_names"], caseName)
+
+    sys.exit(1)
+
+# passing case
+sys.exit(0)

--- a/reg_tests/executeFASTFarmRegressionCase.py
+++ b/reg_tests/executeFASTFarmRegressionCase.py
@@ -118,11 +118,27 @@ if not os.path.isdir(inputsDirectory):
     rtl.exitWithError("The test data inputs directory, {}, does not exist. Verify your local repository is up to date.".format(inputsDirectory))
 
 # create the local output directory if it does not already exist
+dst = os.path.join(buildDirectory, "5MW_Baseline")
+src = os.path.join(moduleDirectory, "5MW_Baseline")
+if not os.path.isdir(dst):
+    shutil.copytree(src, dst)
+else:
+    names = os.listdir(src)
+    for name in names:
+        if name == "ServoData":
+            continue
+        srcname = os.path.join(src, name)
+        dstname = os.path.join(dst, name)
+        if os.path.isdir(srcname):
+            if not os.path.isdir(dstname):
+                shutil.copytree(srcname, dstname)
+        else:
+            shutil.copy2(srcname, dstname)
+
 if not os.path.isdir(testBuildDirectory):
     shutil.copytree(inputsDirectory, testBuildDirectory, ignore=ignoreBaselineItems)
 
 ### Run openfast on the test case
-noExec = True
 if not noExec:
     caseInputFile = os.path.join(testBuildDirectory, caseName + ".fstf")
     returnCode = openfastDrivers.runOpenfastCase(caseInputFile, executable)


### PR DESCRIPTION
**Feature or improvement description**
This pull request adds the regression test infrastructure as well as enables a single regression test (TSinflow) to run within GitHub Actions. It also updates the CMake configuration to search for the Fortran libraries of OpenMP rather than require the C and C++ libraries., as well.

I've also changed the name of the executable from `openfast-farm` to `fast-farm` for consistency with other references to this software.

**Impacted areas of the software**
FAST Farm CMake configuration and regression test infrastructure

**Additional information**
Its not ideal to have multiple copies of the 5MW turbine directory in r-test and multiple copies of the controllers. I'm looking at ways to simplify this, but in the meantime we can continue with the setup here.

Also, the test cases were initially created by @kshaler and updated by me in the `fastfarm` [branch of the r-test](https://github.com/OpenFAST/r-test/tree/fastfarm/glue-codes/fast-farm) repository.
the `LESinflow` test case is not yet enabled due to out of date input files.

For review: @jjonkman @kshaler