### PR TITLE
Remove superfluous CMake flag for FAST Farm

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -109,7 +109,6 @@ jobs:
           cmake \
             -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install \
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
-            -DBUILD_FAST_FARM:BOOL=ON \
             -DOPENMP:BOOL=ON \
             -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
             -DBUILD_TESTING:BOOL=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ option(USE_DLL_INTERFACE "Enable runtime loading of dynamic libraries" on)
 option(FPE_TRAP_ENABLED "Enable FPE trap in compiler options" off)
 option(ORCA_DLL_LOAD "Enable OrcaFlex Library Load" on)
 option(BUILD_OPENFAST_CPP_API "Enable building OpenFAST - C++ API" off)
-option(BUILD_FAST_FARM "Enable building FAST.Farm glue code" off)
 option(OPENMP                 "Enable OpenMP support"              off)
 
 # Precompiler/preprocessor flag configuration
@@ -106,6 +105,8 @@ set(OPENFAST_MODULES
   icedyn
   icefloe
   map
+  wakedynamics
+  awae
 )
 
 set(OPENFAST_REGISTRY_INCLUDES "" CACHE INTERNAL "Registry includes paths")
@@ -118,13 +119,6 @@ set(OPENFAST_REGISTRY_INCLUDES
 foreach(IDIR IN ITEMS ${OPENFAST_MODULES})
   add_subdirectory("${CMAKE_SOURCE_DIR}/modules/${IDIR}")
 endforeach(IDIR IN ITEMS ${OPENFAST_MODULES})
-
-if (BUILD_FAST_FARM)
-  add_subdirectory("${CMAKE_SOURCE_DIR}/modules/wakedynamics")
-  add_subdirectory("${CMAKE_SOURCE_DIR}/modules/awae")
-  set_registry_includes("modules" wakedynamics)
-  set_registry_includes("modules" awae)
-endif()
 
 add_subdirectory(glue-codes)
 

--- a/glue-codes/CMakeLists.txt
+++ b/glue-codes/CMakeLists.txt
@@ -5,7 +5,4 @@ if(BUILD_OPENFAST_CPP_API)
    add_subdirectory(openfast-cpp)
 endif()
 
-if(BUILD_FAST_FARM)
-  add_subdirectory(fast-farm)
-endif()
-
+add_subdirectory(fast-farm)


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
Removes a CMake flag that isn't needed. The FAST Farm target can always be included in CMake and only compiled when users use the `FAST.Farm` target. This does not change the behavior for OpenFAST.
